### PR TITLE
Stop setup script on error

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 echo "Cloning repos..."
 


### PR DESCRIPTION
This change instructs bash to immediately stop script execution if any command has a non-zero exit status.

Before this change, I ran the setup script and looked away for a few minutes and saw that the script completed seemingly successfully as I saw "Done!" as the final output. I then continued to run `docker compose up` and everything started successfully. However, the local Lichess instance wouldn't open modals, powertips, the search bar, etc. While investigating, I realized that the `/ui/build` failed which is executed as part of the setup script. Having an immediate halt on error would be beneficial at catching build failures earlier.
