### PR TITLE
Fix git dubious ownership error when running setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -13,10 +13,10 @@ git submodule update --init
 cd ../..
 
 echo "Compiling lila js/css..."
-docker run --rm -v $(pwd)/repos/lila:/mnt node:latest bash -c "npm install -g pnpm && /mnt/ui/build"
+docker run --rm -v $(pwd)/repos/lila:/mnt node:latest bash -c "git config --global --add safe.directory /mnt && npm install -g pnpm && /mnt/ui/build"
 
 echo "Compiling chessground..."
-docker run --rm -v $(pwd)/repos/chessground:/mnt node:latest bash -c "npm install -g pnpm && cd /mnt && pnpm install && pnpm run compile"
+docker run --rm -v $(pwd)/repos/chessground:/mnt node:latest bash -c "git config --global --add safe.directory /mnt && npm install -g pnpm && cd /mnt && pnpm install && pnpm run compile"
 
 COMPOSE_PROFILES=$(docker-compose config --profiles | xargs | sed -e 's/ /,/g') docker-compose build
 


### PR DESCRIPTION
The script for me was failing during the '/ui/build' step. The error I was receiving is in the screenshot below. I was able to get past the error by having the containers first run `git config --global --add safe.directory /mnt` as directed in the error. This PR adds this command to the setup script.

I'm not sure if others have run into this issue as well, so figured I'd create the PR. If you feel that this is something that could just be a local issue for me, I'm good with you closing this PR as well.

![Screenshot from 2023-08-04 15-26-46](https://github.com/fitztrev/lila-docker/assets/3620552/c8d4ad79-8d63-458d-88a0-6071ff213b88)

Related to #1 