### PR TITLE
Use `docker compose` instead of `docker-compose` in setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -19,6 +19,6 @@ docker run --rm -v $(pwd)/repos/lila:/mnt node:latest bash -c "git config --glob
 echo "Compiling chessground..."
 docker run --rm -v $(pwd)/repos/chessground:/mnt node:latest bash -c "git config --global --add safe.directory /mnt && npm install -g pnpm && cd /mnt && pnpm install && pnpm run compile"
 
-COMPOSE_PROFILES=$(docker-compose config --profiles | xargs | sed -e 's/ /,/g') docker-compose build
+COMPOSE_PROFILES=$(docker compose config --profiles | xargs | sed -e 's/ /,/g') docker compose build
 
 echo "Done!"


### PR DESCRIPTION
Removes the references to `docker-compose` in `setup.sh` and uses `docker compose` instead. `docker-compose` does not come with Docker Desktop. Therefore, those with a fresh installation of just Docker Desktop on their computer will run into errors.

From previous work, I had `docker-compose` already installed on my computer which is why the setup was passing for me initially. I removed `docker-compose` from my computer (leaving just Docker Desktop) and the setup failed without the changes in this PR.